### PR TITLE
better integrate into owncloud.dev

### DIFF
--- a/docs/extensions/wopiserver/_index.md
+++ b/docs/extensions/wopiserver/_index.md
@@ -1,5 +1,6 @@
 ---
-title: oCIS WOPI server
+title: WOPI server
+weight: 20
 geekdocRepo: https://github.com/owncloud/ocis-wopiserver
 geekdocEditPath: edit/main/docs/extensions/wopiserver
 geekdocFilePath: _index.md


### PR DESCRIPTION
- use same weight as all other extensions
- don't prefix extension name with oCIS